### PR TITLE
feat(Command): add support to fetch presences and user_ids

### DIFF
--- a/lib/gateway/command.ex
+++ b/lib/gateway/command.ex
@@ -162,7 +162,7 @@ defmodule Crux.Gateway.Command do
           opts ::
             [
               {:query, String.t()}
-              | {:limit, pos_integer()}
+              | {:limit, non_neg_integer()}
               | {:presences, boolean()}
               | {:user_ids, Crux.Structs.Snowflake.t() | [Crux.Structs.Snowflake.t()]}
             ]

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -1,0 +1,62 @@
+defmodule Crux.Gateway.CommandTest do
+  use ExUnit.Case
+  doctest Crux.Gateway.Command
+
+  # Since the commands directly make it WebSocket friendly
+  defp unfinalize({:binary, data}) do
+    %{"d" => d} = :erlang.binary_to_term(data)
+
+    d
+  end
+
+  describe "request_guild_members/1,2" do
+    # Get the guild_id out of the way
+    def request_guild_members(opts \\ []) do
+      Crux.Gateway.Command.request_guild_members(1234, opts)
+    end
+
+    # Builds the expected map, including defaults
+    defp build_expected(opts) do
+      opts = Map.new(opts, fn {k, v} -> {to_string(k), v} end)
+
+      %{"guild_id" => 1234, "limit" => 0, "presences" => false}
+      |> Map.merge(opts)
+    end
+
+    test "/1" do
+      received = request_guild_members() |> unfinalize()
+      # The default is all of them
+      expected = build_expected(query: "")
+
+      assert received === expected
+    end
+
+    test "all options" do
+      opts = %{query: "space", limit: 15, user_ids: [1, 2, 3], presences: true}
+
+      received = request_guild_members(opts) |> unfinalize()
+
+      expected = build_expected(query: "space", limit: 15, user_ids: [1, 2, 3], presences: true)
+
+      assert received === expected
+    end
+
+    test "query does not return user_ids" do
+      opts = [query: "space"]
+
+      received = request_guild_members(opts) |> unfinalize()
+      expected = build_expected(query: "space")
+
+      assert received === expected
+    end
+
+    test "user_ids does not return query" do
+      opts = [user_ids: [1, 2, 3]]
+
+      received = request_guild_members(opts) |> unfinalize()
+      expected = build_expected(user_ids: [1, 2, 3])
+
+      assert received === expected
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
This PR adds support to specify `presences` and `user_ids` when fetching guild members via `Crux.Gateway.Command.request_guild_members/2`.

Documenting PRs:
- `user_ids` was added with https://github.com/discordapp/discord-api-docs/pull/1078
- `presences` will (hopefully) be added with https://github.com/discordapp/discord-api-docs/pull/1116